### PR TITLE
Quick fix to tests when run as part of another project

### DIFF
--- a/ganalytics/tests.py
+++ b/ganalytics/tests.py
@@ -27,6 +27,7 @@ class GoogleAnalytics(TestCase):
         self.assertEqual(self.render('{% load ganalytics %}{% ganalytics %}'), '')
 
     def test_render_returns_javascript_code_if_setting_exists(self):
+        settings.GANALYTICS_TRACKING_CODE = 'UA-12345678-90'
         self.assertIn('UA-12345678-90', self.render('{% load ganalytics %}{% ganalytics %}'))
 
     def tearDown(self):


### PR DESCRIPTION
One of the tests expects the tracking id to be set. This is done by the test project but not necessarily by another project including the app. This fix should always set the right id without compromising the test.
