### PR TITLE
Adds support for Django 1.11

### DIFF
--- a/ganalytics/templatetags/ganalytics.py
+++ b/ganalytics/templatetags/ganalytics.py
@@ -17,6 +17,6 @@ def ganalytics():
     defined a ``GANALYTICS_TRACKING_CODE`` setting.
     """
     if (not settings.DEBUG) and getattr(settings, 'GANALYTICS_TRACKING_CODE', False):
-        context = Context({'GANALYTICS_TRACKING_CODE': settings.GANALYTICS_TRACKING_CODE})
+        context = {'GANALYTICS_TRACKING_CODE': settings.GANALYTICS_TRACKING_CODE}
         return get_template('ganalytics/ganalytics.js').render(context)
     return ''

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Basic package information:
     name = 'django-ganalytics',
-    version = '0.4',
+    version = '0.5',
     packages = ['ganalytics'],
 
     # Packaging options:

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,5 +1,10 @@
 # Django settings for test_project project.
 
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
@@ -90,6 +95,22 @@ TEMPLATE_LOADERS = (
 #     'django.template.loaders.eggs.Loader',
 )
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 MIDDLEWARE_CLASSES = (
     'sslify.middleware.SSLifyMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -100,6 +121,17 @@ MIDDLEWARE_CLASSES = (
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+MIDDLEWARE = [
+    'sslify.middleware.SSLifyMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    # Uncomment the next line for simple clickjacking protection:
+    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
 
 ROOT_URLCONF = 'test_project.urls'
 

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,10 +1,12 @@
-from django.conf.urls import patterns, include, url
+from django.conf import settings
+from django.conf.urls import include, url
+from django.conf.urls.static import static
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'test_project.views.home', name='home'),
     # url(r'^test_project/', include('test_project.foo.urls')),
@@ -14,4 +16,4 @@ urlpatterns = patterns('',
 
     # Uncomment the next line to enable the admin:
     # url(r'^admin/', include(admin.site.urls)),
-)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-render-prohibits-non-dict-context Context is now passed as a dict rather than as a Context object